### PR TITLE
Fix typo in documentation's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add script right before closing ``</body>`` tag:
 </script>
 ```
 
-### For more detailed instruction please visit [https://webfullset.com/wfsnav/](https://webfullset.com/wfscnav/)
+### For more detailed instruction please visit [https://webfullset.com/wfsnav/](https://webfullset.com/wfsnav/)
 
 <br>
 


### PR DESCRIPTION
Detailed instruction link used to redirect `https://webfullset.com/wfscnav/` (with a "c" between wfs and nav) leading to a 404